### PR TITLE
add:  extension for finding website tech stack

### DIFF
--- a/wapplyzer-tech-finder-extension/extension/background.js
+++ b/wapplyzer-tech-finder-extension/extension/background.js
@@ -1,0 +1,7 @@
+chrome.action.onClicked.addListener((tab) => {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['content.js']
+    });
+  });
+  

--- a/wapplyzer-tech-finder-extension/extension/content.js
+++ b/wapplyzer-tech-finder-extension/extension/content.js
@@ -1,0 +1,9 @@
+async function detectTechnologies() {
+    const wasm = await import(chrome.runtime.getURL('pkg/your_wasm_package.js'));
+    const detectedTechs = wasm.detect_technologies();
+    console.log("Detected Technologies:", detectedTechs);
+    // Here you could add code to display this info in the popup.
+  }
+  
+  detectTechnologies();
+  

--- a/wapplyzer-tech-finder-extension/extension/mainfest.json
+++ b/wapplyzer-tech-finder-extension/extension/mainfest.json
@@ -1,0 +1,24 @@
+{
+    "manifest_version": 3,
+    "name": "Rust Wappalyzer Clone",
+    "version": "1.0",
+    "permissions": ["tabs", "scripting"],
+    "background": {
+      "service_worker": "background.js"
+    },
+    "content_scripts": [
+      {
+        "matches": ["<all_urls>"],
+        "js": ["content.js"]
+      }
+    ],
+    "action": {
+      "default_popup": "popup.html",
+      "default_icon": {
+        "16": "icon16.png",
+        "48": "icon48.png",
+        "128": "icon128.png"
+      }
+    }
+  }
+  

--- a/wapplyzer-tech-finder-extension/extension/popup.html
+++ b/wapplyzer-tech-finder-extension/extension/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Detected Technologies</title>
+  <script src="popup.js"></script>
+</head>
+<body>
+  <h3>Detected Technologies</h3>
+  <ul id="tech-list"></ul>
+</body>
+</html>

--- a/wapplyzer-tech-finder-extension/extension/popup.js
+++ b/wapplyzer-tech-finder-extension/extension/popup.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const techList = document.getElementById('tech-list');
+    const detectedTechs = await detectTechnologies(); // You would need to call the function here or use messaging to fetch results
+    detectedTechs.forEach(tech => {
+      const listItem = document.createElement('li');
+      listItem.textContent = tech;
+      techList.appendChild(listItem);
+    });
+  });
+  

--- a/wapplyzer-tech-finder-extension/src/lib.rs
+++ b/wapplyzer-tech-finder-extension/src/lib.rs
@@ -1,0 +1,20 @@
+use wasm_bindgen::prelude::*;
+use web_sys::{window, Document};
+
+#[wasm_bindgen]
+pub fn detect_technologies() -> JsValue {
+    let document = window().unwrap().document().unwrap();
+    let mut detected = vec![];
+
+    // Example: Detect jQuery by checking if "$" function exists
+    if js_sys::eval("typeof $ === 'function' && $.fn && $.fn.jquery").unwrap().as_bool().unwrap() {
+        detected.push("jQuery");
+    }
+
+    // Example: Detect Bootstrap by checking for specific classes in the DOM
+    if document.query_selector(".container").is_ok() {
+        detected.push("Bootstrap");
+    }
+
+    JsValue::from_serde(&detected).unwrap()
+}


### PR DESCRIPTION
This extension is clone of wappalyzer, this extension helps you to find tech stack used in the web app and clound services used from scraping the relevant information.