### PR TITLE
Add: Rate Limitting API's

### DIFF
--- a/rate-limitter/Cargo.toml
+++ b/rate-limitter/Cargo.toml
@@ -1,0 +1,4 @@
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.11", features = ["json"] }
+futures = "0.3"

--- a/rate-limitter/readme.md
+++ b/rate-limitter/readme.md
@@ -1,0 +1,11 @@
+Rate-Limited API Client in Rust
+This project demonstrates how to implement a simple rate-limited API client in Rust using tokio and reqwest. It allows you to make concurrent API requests while respecting a rate limit (e.g., 5 requests per second).
+
+Features
+Rate limit API requests to a specified number of requests per second.
+Use of tokio async runtime for concurrent request handling.
+Basic example to demonstrate rate-limited API calls using a semaphore.
+Prerequisites
+Rust (version 1.60 or higher)
+Cargo (Rust's package manager and build system)
+An async runtime (tokio) and an HTTP client library (reqwest)

--- a/rate-limitter/src/main.rs
+++ b/rate-limitter/src/main.rs
@@ -1,0 +1,70 @@
+use reqwest::Error;
+use std::time::{Duration, Instant};
+use tokio::sync::Semaphore;
+use tokio::time::sleep;
+use futures::future::join_all;
+
+const RATE_LIMIT: usize = 5; // 5 requests per second
+const API_URL: &str = "https://api.example.com/data"; // Example API URL
+
+// The rate limiter controls access to the API requests
+struct RateLimiter {
+    semaphore: Semaphore,
+    interval: Duration,
+    last_request: Instant,
+}
+
+impl RateLimiter {
+    fn new(rate_limit: usize) -> Self {
+        RateLimiter {
+            semaphore: Semaphore::new(rate_limit),
+            interval: Duration::from_secs(1),
+            last_request: Instant::now(),
+        }
+    }
+
+    async fn acquire(&self) {
+        // Wait for a permit to proceed with the request
+        let permit = self.semaphore.acquire().await.unwrap();
+
+        // Calculate the time between requests to stay within rate limit
+        let elapsed = self.last_request.elapsed();
+        if elapsed < self.interval {
+            let sleep_duration = self.interval - elapsed;
+            sleep(sleep_duration).await;
+        }
+
+        // Update the last request time and release the permit
+        self.last_request = Instant::now();
+        drop(permit);
+    }
+
+    async fn make_request(&self) -> Result<String, Error> {
+        self.acquire().await;
+
+        let response = reqwest::get(API_URL).await?;
+        let body = response.text().await?;
+        Ok(body)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let rate_limiter = RateLimiter::new(RATE_LIMIT);
+
+    let mut handles = vec![];
+
+    // Make concurrent API requests while respecting rate limit
+    for _ in 0..10 {
+        let limiter = rate_limiter.clone();
+        handles.push(tokio::spawn(async move {
+            match limiter.make_request().await {
+                Ok(response) => println!("API response: {}", response),
+                Err(err) => eprintln!("Error: {}", err),
+            }
+        }));
+    }
+
+    // Wait for all requests to finish
+    join_all(handles).await;
+}


### PR DESCRIPTION
RateLimiter: The struct that controls the rate limit for the API. It uses a Semaphore to limit the number of concurrent requests. The acquire method ensures that requests are spaced out and don't exceed the specified rate limit.
acquire: This method checks if enough time has passed since the last request and ensures that requests happen at the rate of RATE_LIMIT per second.
make_request: This method acquires a permit and makes an API request. If the rate limit hasn't been reached, it will wait for the appropriate amount of time.
tokio::main: The async main function where we spawn multiple concurrent tasks (API requests) while maintaining the rate limit.