### PR TITLE
new project added: Rusty Repo Doctor

### DIFF
--- a/Rusty-Repo-Doctor/Cargo.toml
+++ b/Rusty-Repo-Doctor/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rusty_repo_doctor"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+git2 = "0.13"
+cargo_metadata = "0.14" # For reading Cargo.toml dependencies
+serde = { version = "1.0", features = ["derive"] } # For JSON parsing of metadata
+serde_json = "1.0"

--- a/Rusty-Repo-Doctor/Readme.md
+++ b/Rusty-Repo-Doctor/Readme.md
@@ -1,0 +1,27 @@
+# Rusty Repo Doctor
+
+**Rusty Repo Doctor** is a CLI tool designed to perform basic analysis on Rust projects. This tool provides a simple way to analyze Git repositories and check for outdated dependencies in `Cargo.toml`. It’s ideal for developers looking to maintain clean and manageable codebases.
+
+## Features
+
+- **Dependency Checker**: Scans dependencies listed in `Cargo.toml` and provides version information.
+- **Repository Analysis**: Analyzes Git repository details, such as counting the total number of commits in `HEAD`.
+
+This project is a work in progress and can be extended to include additional features, such as checking for outdated dependencies, code quality analysis, and more!
+
+## Getting Started
+
+### Prerequisites
+
+To run **Rusty Repo Doctor**, you’ll need:
+
+- **Rust** (version 1.56+ is recommended)
+- **Cargo** (Rust's package manager)
+
+### Installation
+
+Clone the repository and navigate to the project directory:
+
+```bash
+git clone https://github.com/yourusername/rusty_repo_doctor.git
+cd rusty_repo_doctor

--- a/Rusty-Repo-Doctor/src/main.rs
+++ b/Rusty-Repo-Doctor/src/main.rs
@@ -1,0 +1,11 @@
+use git2::Repository;
+use cargo_metadata::{MetadataCommand, Dependency};
+use std::path::Path;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct DependencyInfo {
+    name: String,
+    version: String,
+    is_outdated: bool,
+}

--- a/Rusty-Repo-Doctor/src/main.rs
+++ b/Rusty-Repo-Doctor/src/main.rs
@@ -31,3 +31,21 @@ fn main() {
         Err(e) => eprintln!("Error checking dependencies: {:?}", e),
     }
 }
+
+/// Checks for outdated dependencies in Cargo.toml
+fn check_dependencies() -> Result<Vec<DependencyInfo>, Box<dyn std::error::Error>> {
+    let metadata = MetadataCommand::new().exec()?;
+    let mut dependencies = Vec::new();
+
+    for package in metadata.packages {
+        for dep in package.dependencies.iter() {
+            dependencies.push(DependencyInfo {
+                name: dep.name.clone(),
+                version: dep.req.to_string(),
+                is_outdated: false, // Placeholder; here we would ideally check against the latest version
+            });
+        }
+    }
+
+    Ok(dependencies)
+}

--- a/Rusty-Repo-Doctor/src/main.rs
+++ b/Rusty-Repo-Doctor/src/main.rs
@@ -9,3 +9,25 @@ struct DependencyInfo {
     version: String,
     is_outdated: bool,
 }
+
+fn main() {
+    // Get repository info
+    match analyze_git_repo(".") {
+        Ok(_) => println!("Repository analysis complete."),
+        Err(e) => eprintln!("Error analyzing repository: {:?}", e),
+    }
+
+    // Check dependencies
+    match check_dependencies() {
+        Ok(dependencies) => {
+            println!("Dependencies Analysis:");
+            for dep in dependencies {
+                println!(
+                    "Dependency: {} - Version: {} - Outdated: {}",
+                    dep.name, dep.version, dep.is_outdated
+                );
+            }
+        }
+        Err(e) => eprintln!("Error checking dependencies: {:?}", e),
+    }
+}


### PR DESCRIPTION
Rusty Repo Doctor is a CLI tool designed to perform basic analysis on Rust projects. This tool provides a simple way to analyze Git repositories and check for outdated dependencies in Cargo.toml. It’s ideal for developers looking to maintain clean and manageable codebases.