### PR TITLE
add: nlp model pipeline in rust

### DIFF
--- a/nlp-pipeline/Cargo.toml
+++ b/nlp-pipeline/Cargo.toml
@@ -1,0 +1,4 @@
+[dependencies]
+tch = "0.11.0" # For PyTorch bindings
+tokenizers = "0.13.3" # For handling tokenization
+serde = { version = "1.0", features = ["derive"] } # For serialization and deserialization

--- a/nlp-pipeline/src/main.rs
+++ b/nlp-pipeline/src/main.rs
@@ -36,4 +36,9 @@ let tokenizer = Tokenizer::from_pretrained("gpt2", None)?;
      let predicted_token_id = logits.argmax(2, true).int64_value(&[0, 0]);
      let predicted_token = tokenizer.decode(vec![predicted_token_id as u32], true)?;
 
+     println!("Input: {}", input_text);
+     println!("Next Token: {}", predicted_token);
+ 
+     Ok(())
+
 }

--- a/nlp-pipeline/src/main.rs
+++ b/nlp-pipeline/src/main.rs
@@ -15,4 +15,8 @@ let tokenizer = Tokenizer::from_pretrained("gpt2", None)?;
     Device::Cpu
 };
 
+/ Load a pre-trained model (e.g., GPT-2)
+    let vs = nn::VarStore::new(device);
+    let model = tch::CModule::load_on_device("gpt2.pt", device)?;
+
 }

--- a/nlp-pipeline/src/main.rs
+++ b/nlp-pipeline/src/main.rs
@@ -8,6 +8,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 // Load a pre-trained tokenizer (e.g., GPT-2)
 let tokenizer = Tokenizer::from_pretrained("gpt2", None)?;
 
-
+ // Set up the device (use GPU if available)
+ let device = if tch::Cuda::is_available() {
+    Device::Cuda(0)
+} else {
+    Device::Cpu
+};
 
 }

--- a/nlp-pipeline/src/main.rs
+++ b/nlp-pipeline/src/main.rs
@@ -1,0 +1,2 @@
+use tch::{nn, Device, Tensor};
+use tokenizers::{Tokenizer, PaddingParams, TruncationParams};

--- a/nlp-pipeline/src/main.rs
+++ b/nlp-pipeline/src/main.rs
@@ -28,4 +28,12 @@ let tokenizer = Tokenizer::from_pretrained("gpt2", None)?;
           .unsqueeze(0) // Add batch dimension
           .to(device);
 
+     // Forward pass through the model
+     let output = model.forward_ts(&[input_ids])?;
+     let logits = output.get(0).unwrap(); // Get logits from the output
+ 
+     // Decode output tokens
+     let predicted_token_id = logits.argmax(2, true).int64_value(&[0, 0]);
+     let predicted_token = tokenizer.decode(vec![predicted_token_id as u32], true)?;
+
 }

--- a/nlp-pipeline/src/main.rs
+++ b/nlp-pipeline/src/main.rs
@@ -15,8 +15,17 @@ let tokenizer = Tokenizer::from_pretrained("gpt2", None)?;
     Device::Cpu
 };
 
-/ Load a pre-trained model (e.g., GPT-2)
+//  Load a pre-trained model (e.g., GPT-2)
     let vs = nn::VarStore::new(device);
     let model = tch::CModule::load_on_device("gpt2.pt", device)?;
+
+      // Input sentence
+      let input_text = "Once upon a time";
+
+      // Tokenize the input
+      let encoding = tokenizer.encode(input_text, true)?;
+      let input_ids = Tensor::of_slice(&encoding.get_ids().iter().map(|&x| x as i64).collect::<Vec<_>>())
+          .unsqueeze(0) // Add batch dimension
+          .to(device);
 
 }

--- a/nlp-pipeline/src/main.rs
+++ b/nlp-pipeline/src/main.rs
@@ -1,2 +1,13 @@
 use tch::{nn, Device, Tensor};
 use tokenizers::{Tokenizer, PaddingParams, TruncationParams};
+
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+
+
+// Load a pre-trained tokenizer (e.g., GPT-2)
+let tokenizer = Tokenizer::from_pretrained("gpt2", None)?;
+
+
+
+}


### PR DESCRIPTION
Creating a language model in Rust involves implementing a basic natural language processing (NLP) pipeline. While Rust does not have as many mature NLP libraries as Python, we can leverage libraries like [tch-rs](https://github.com/LaurentMazare/tch-rs) for working with pre-trained models (e.g., GPT, BERT) using Torch bindings.