### PR TITLE
add: task orchestrator cli tool in rust

### DIFF
--- a/linear-regression/src/model.rs
+++ b/linear-regression/src/model.rs
@@ -1,0 +1,16 @@
+use linfa::prelude::*;
+use linfa_linear::LinearRegression;
+use ndarray::Array2;
+
+/// Train a linear regression model
+pub fn train_model(features: &Array2<f64>, targets: &Array2<f64>) -> LinearRegression {
+    let dataset = Dataset::new(features.clone(), targets.clone());
+    LinearRegression::new()
+        .fit(&dataset)
+        .expect("Failed to fit the model")
+}
+
+/// Predict using the trained model
+pub fn predict(model: &LinearRegression, inputs: &Array2<f64>) -> Array2<f64> {
+    model.predict(inputs)
+}

--- a/task-orchestrator/Cargo.toml
+++ b/task-orchestrator/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "task_orchestrator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.1", features = ["derive"] } # For CLI parsing
+serde = { version = "1.0", features = ["derive"] } # For parsing YAML/JSON
+tokio = { version = "1.32", features = ["full"] } # For async task handling
+tracing = "0.1" # For logging
+serde_yaml = "0.9" # For YAML parsing
+serde_json = "1.0" # For JSON parsing
+
+[dependencies.anyhow]
+version = "1.0" # For error handling
+features = ["backtrace"]
+

--- a/task-orchestrator/src/main.rs
+++ b/task-orchestrator/src/main.rs
@@ -11,3 +11,8 @@ struct Task {
     command: String,
     depends_on: Option<Vec<String>>,
 }
+
+#[derive(Debug, Deserialize)]
+struct Workflow {
+    tasks: Vec<Task>,
+}

--- a/task-orchestrator/src/main.rs
+++ b/task-orchestrator/src/main.rs
@@ -1,0 +1,6 @@
+use clap::{Arg, Command};
+use serde::Deserialize;
+use std::fs;
+use tokio::process::Command as TokioCommand;
+use tracing::{info, Level};
+use tracing_subscriber;

--- a/task-orchestrator/src/main.rs
+++ b/task-orchestrator/src/main.rs
@@ -16,3 +16,37 @@ struct Task {
 struct Workflow {
     tasks: Vec<Task>,
 }
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .init();
+
+    // Parse CLI arguments
+    let matches = Command::new("Task Orchestrator")
+        .version("0.1.0")
+        .about("An intelligent CLI Task Orchestrator")
+        .arg(
+            Arg::new("workflow")
+                .short('w')
+                .long("workflow")
+                .takes_value(true)
+                .help("Path to the workflow YAML file"),
+        )
+        .get_matches();
+
+    let workflow_path = matches
+        .value_of("workflow")
+        .ok_or_else(|| anyhow::anyhow!("Workflow file is required"))?;
+
+    // Load and parse the workflow
+    let workflow_data = fs::read_to_string(workflow_path)?;
+    let workflow: Workflow = serde_yaml::from_str(&workflow_data)?;
+
+    // Execute the workflow
+    execute_workflow(workflow).await?;
+
+    Ok(())
+}

--- a/task-orchestrator/src/main.rs
+++ b/task-orchestrator/src/main.rs
@@ -4,3 +4,10 @@ use std::fs;
 use tokio::process::Command as TokioCommand;
 use tracing::{info, Level};
 use tracing_subscriber;
+
+#[derive(Debug, Deserialize)]
+struct Task {
+    name: String,
+    command: String,
+    depends_on: Option<Vec<String>>,
+}

--- a/task-orchestrator/src/main.rs
+++ b/task-orchestrator/src/main.rs
@@ -49,4 +49,38 @@ async fn main() -> anyhow::Result<()> {
     execute_workflow(workflow).await?;
 
     Ok(())
+
+
+
+}
+
+
+async fn execute_workflow(workflow: Workflow) -> anyhow::Result<()> {
+    info!("Starting workflow execution...");
+
+    for task in &workflow.tasks {
+        info!("Executing task: {}", task.name);
+        let output = TokioCommand::new("sh")
+            .arg("-c")
+            .arg(&task.command)
+            .output()
+            .await?;
+
+        if output.status.success() {
+            info!(
+                "Task '{}' completed successfully",
+                task.name
+            );
+        } else {
+            tracing::error!(
+                "Task '{}' failed with error: {:?}",
+                task.name,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Err(anyhow::anyhow!("Task '{}' failed", task.name));
+        }
+    }
+
+    info!("Workflow execution completed.");
+    Ok(())
 }


### PR DESCRIPTION
How It Works
The CLI accepts a --workflow argument pointing to a YAML file.
It parses the YAML file into a Workflow struct containing tasks.
Each task is executed in sequence using Tokio's async capabilities.
Dependencies are not yet enforced (can be extended).
Outputs are logged using the tracing crate.